### PR TITLE
feat: console simulation loop und stabile Kräfte (Issue #5)

### DIFF
--- a/particle_life/main.py
+++ b/particle_life/main.py
@@ -1,1 +1,35 @@
-pass
+#import time
+import numpy as np
+
+import particle_life.config as config
+from particle_life.simulation import ParticleSystem
+
+
+def run_console() -> None:
+    if config.SEED is not None:
+        np.random.seed(config.SEED)
+
+    sim = ParticleSystem()
+    step = 0
+
+    try:
+        while True:
+            sim.update(config.DT)
+            if step % 10 == 0:
+                pos = sim.get_positions()
+                mean = pos.mean(axis=0)
+                first5 = pos[:5].round(2).tolist()
+                print(
+                    f"step={step} "
+                    f"mean=({mean[0]:.2f},{mean[1]:.2f}) "
+                    f"first5={first5}"
+                )
+            step += 1
+            # time.sleep(0.01)  # optional: CPU schonen
+    except KeyboardInterrupt:
+        print(f"\nStopped at step {step}")
+
+
+if __name__ == "__main__":
+    run_console()
+

--- a/particle_life/simulation.py
+++ b/particle_life/simulation.py
@@ -77,6 +77,7 @@ class ParticleSystem:
         friction = np.float32(self.friction)
         r_max = np.float32(config.MAX_RADIUS)
         force_factor = np.float32(config.FORCE_FACTOR)
+        min_distance = np.float32(config.MIN_DISTANCE)
 
         disp = self._disp
         dist2 = self._dist2
@@ -102,10 +103,14 @@ class ParticleSystem:
 
         # Distanzen + Falloff
         dist = np.sqrt(dist2, dtype=np.float32)  # kleines temporäres Array
-        np.where(within, 1.0 - dist / r_max, 0.0, out=force_mag)  # force_mag = falloff
+        # Mindestabstand, um Division durch 0 zu vermeiden
+        dist[within] = np.maximum(dist[within], min_distance)
+        np.copyto(force_mag, 1.0 - dist / r_max, where=within)
+        force_mag[~within] = 0.0  # außerhalb des Radius keine Kraft
 
         # Richtungsvektoren normalisieren; wo not within -> 0
         inv_dist = np.divide(1.0, dist, out=dist, where=within)  # dist wird zu inv_dist
+        inv_dist[~within] = 0.0
         force_dir[:] = disp * inv_dist[..., None]
 
         # Stärke aus Interaktionsmatrix pro Typenpaar


### PR DESCRIPTION
Summary:

main.py: Konsolen-Simulation mit Init, Endlosschleife, Update und Ausgabe alle 10 Schritte (Durchschnittsposition, erste 5 Partikel), sauberer Ctrl+C-Abbruch, optionaler Sleep.

simulation.py: Stabilere Kräfte (MIN_DISTANCE aus config, Masking von inv_dist außerhalb des Radius) verhindert NaNs.

Closes: #5

Testing: ruff check (grün), manueller Lauf python -m particle_life.main ok.