### PR TITLE
Fix direct execution of viewer.py (Issue #30)

### DIFF
--- a/particle_life/viewer.py
+++ b/particle_life/viewer.py
@@ -1,10 +1,25 @@
 import sys
+from pathlib import Path
 
 import numpy as np
 import pygame
 
-import particle_life.config as config
-from particle_life.simulation import ParticleSystem
+
+def _import_dependencies():
+    try:
+        import particle_life.config as config
+        from particle_life.simulation import ParticleSystem
+        return config, ParticleSystem
+    except ModuleNotFoundError:
+        root_dir = Path(__file__).resolve().parent.parent
+        if str(root_dir) not in sys.path:
+            sys.path.insert(0, str(root_dir))
+        import particle_life.config as config
+        from particle_life.simulation import ParticleSystem
+        return config, ParticleSystem
+
+
+config, ParticleSystem = _import_dependencies()
 
 
 def run() -> None:


### PR DESCRIPTION
Dieses PR implementiert für Issue #30 einen Pfad‑Fix in `viewer.py`, sodass die Datei auch direkt (z.B. per Run‑Button in der IDE oder `python particle_life/viewer.py`) ohne Import‑Fehler gestartet werden kann.

**Änderungen**

- Implementierung einer Import-Hilfsfunktion am Anfang von `particle_life/viewer.py`:
  - Versucht zuerst, `particle_life.config` und `particle_life.simulation` ganz normal als Paket zu importieren.
  - Fängt einen `ModuleNotFoundError` ab, wenn `viewer.py` direkt aus dem `particle_life`‑Ordner gestartet wird.
  - Ergänzt in diesem Fall automatisch das Projekt-Root (`parent.parent` von `viewer.py`) im `sys.path` und wiederholt den Import.

- Zentrale Zuweisung der Abhängigkeiten über:
  - `config, ParticleSystem = _import_dependencies()`
  - Der restliche Code des Viewers (Simulation, Zeichnen, Steuerung) kann unverändert weiterarbeiten.

