### PR TITLE
Add test for particle movement issue 31 

### DIFF
--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from particle_life.simulation import ParticleSystem
 
 
@@ -11,3 +13,23 @@ def test_create_system():
     # Wir prüfen, ob die Arrays die richtige Größe haben
     assert len(sim.get_positions()) == 10
     assert len(sim.get_types()) == 10
+
+
+def test_particles_move(small_particle_system):
+    """
+    Prüft, dass sich Partikelpositionen nach update() verändern,
+    wenn eine Geschwindigkeit gesetzt ist.
+    """
+    sim = small_particle_system
+
+    # Keine Interaktionskräfte, damit nur Bewegung durch Velocity zählt.
+    sim.interaction_matrix[:] = 0.0
+    sim.velocities = np.full((sim.n_particles, 2), [5.0, 0.0], dtype=np.float32)
+
+    positions_before = sim.positions.copy()
+
+    sim.update()
+
+    positions_after = sim.positions
+
+    assert np.any(positions_after != positions_before)


### PR DESCRIPTION
Adds a unit test to verify that particle positions change after an update when velocities are set

Details
- Uses the `small_particle_system` fixture
- Assigns a uniform positive x-velocity to all particles
- Captures positions before the update
- Calls `update()` once
- Asserts positions differ using `numpy.any`